### PR TITLE
Read added data in parallel read streams, and transform in parallel

### DIFF
--- a/python/src/space/core/options.py
+++ b/python/src/space/core/options.py
@@ -19,6 +19,9 @@ from typing import Any, Callable, List, Optional
 
 import pyarrow.compute as pc
 
+# Default number of rows per batch in read result.
+DEFAULT_READ_BATCH_SIZE = 16
+
 
 @dataclass
 class ReadOptions:
@@ -50,7 +53,7 @@ class ReadOptions:
   batch_size: Optional[int] = None
 
   def __post_init__(self):
-    self.batch_size = self.batch_size or 16
+    self.batch_size = self.batch_size or DEFAULT_READ_BATCH_SIZE
 
 
 @dataclass

--- a/python/src/space/core/runners.py
+++ b/python/src/space/core/runners.py
@@ -81,8 +81,19 @@ class BaseReadOnlyRunner(ABC):
   def diff(self, start_version: Union[int],
            end_version: Union[int]) -> Iterator[ChangeData]:
     """Read the change data between two versions.
-    
-    start_version is excluded; end_version is included. 
+
+    NOTE: it has limitations:
+    - For DELETE change type, only primary keys are returned
+    - DELETE changes are not processed by the UDF in transforms. For `filter`
+      transform, it may return additional rows that are deleted in source but
+      should be filtered in target. It does not affect correctness of sync.
+
+    Args:
+      start_version: start version, not included in result
+      end_version: end version, included in result
+
+    Return:
+      An iterator of change data
     """
 
 

--- a/python/src/space/core/views.py
+++ b/python/src/space/core/views.py
@@ -155,6 +155,10 @@ class View(ABC):
              fn: Callable,
              input_fields: Optional[List[str]] = None) -> View:
     """Filter rows by the provided user defined function.
+
+    TODO: this filter is not applied to the deleted rows returned by diff(), it
+    thus returns more rows than expected. It does not affect correctness when
+    syncing the deletion to target MV, because the additional rows don't exist.
     
     Args:
       fn: a user defined function on batches.

--- a/python/tests/core/ops/test_change_data.py
+++ b/python/tests/core/ops/test_change_data.py
@@ -45,14 +45,9 @@ def test_read_change_data(tmp_path, all_types_schema, all_types_input_data):
   runner.delete((pc.field("string") == "a") | (pc.field("string") == "A"))
   changes = list(runner.diff(1, 2))
   assert len(changes) == 1
-  expected_change1 = ChangeData(
-      ds.storage.metadata.current_snapshot_id, ChangeType.DELETE,
-      pa.Table.from_pydict({
-          "int64": [1, 0],
-          "float64": [0.1, -0.1],
-          "bool": [True, False],
-          "string": ["a", "A"]
-      }))
+  expected_change1 = ChangeData(ds.storage.metadata.current_snapshot_id,
+                                ChangeType.DELETE,
+                                pa.Table.from_pydict({"int64": [1, 0]}))
   assert changes[0] == expected_change1
 
   # Validate Upsert operation's changes.
@@ -65,14 +60,9 @@ def test_read_change_data(tmp_path, all_types_schema, all_types_input_data):
   runner.upsert(upsert_data)
   changes = list(runner.diff(2, 3))
   assert len(changes) == 2
-  expected_change2 = ChangeData(
-      ds.storage.metadata.current_snapshot_id, ChangeType.DELETE,
-      pa.Table.from_pydict({
-          "int64": [2, 3],
-          "float64": [0.2, 0.3],
-          "bool": [False, False],
-          "string": ["b", "c"]
-      }))
+  expected_change2 = ChangeData(ds.storage.metadata.current_snapshot_id,
+                                ChangeType.DELETE,
+                                pa.Table.from_pydict({"int64": [2, 3]}))
   expected_change3 = ChangeData(ds.storage.metadata.current_snapshot_id,
                                 ChangeType.ADD,
                                 pa.Table.from_pydict(upsert_data))


### PR DESCRIPTION
- Read added data in parallel read streams, and transform in parallel
- Only read primary keys, and skip transform UDF processing, for DELETE change types. It has limitations, we can add options to control behavior, based on feedbacks
